### PR TITLE
fix spec_helper.rb

### DIFF
--- a/test/integration/win/serverspec/localhost/default_spec.rb
+++ b/test/integration/win/serverspec/localhost/default_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe file('/inetpub/wwwroot/index.html') do
   it { should be_file }
-  it { should contain "Hello world" }
+  its(:content) { should match /Hello world/ }
 end
 
 describe service('W3SVC') do

--- a/test/integration/win/serverspec/spec_helper.rb
+++ b/test/integration/win/serverspec/spec_helper.rb
@@ -1,4 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::Cmd
-include Serverspec::Helper::Windows
+set :backend, :cmd


### PR DESCRIPTION
Changing [spec_helper.rb](https://github.com/afiune/tk-windows/blob/master/test/integration/win/serverspec/spec_helper.rb) to include `+set :backend, :cmd` allows serverspec to execute properly (tho the `it { should contain "Hello world" }` test still doesn't seem to pass for some reason). With the current config I was getting the following error:

```
$ kitchen verify win-windows-2012R2
-----> Starting Kitchen (v1.3.0)
-----> Verifying <win-windows-2012R2>...
       Removing /tmp/busser/suites/serverspec
Uploading /tmp/busser/suites/serverspec/localhost/default_spec.rb (mode=0664)
Uploading /tmp/busser/suites/serverspec/spec_helper.rb (mode=0664)
-----> Running serverspec test suite
       C:/opscode/chef/embedded/bin/ruby.exe -IC:/tmp/busser/suites/serverspec -I'C:/tmp/busser/gems/gems/rspec-support-3.1.2/lib';'C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib' C:/tmp/busser/gems/gems/rspec-core-3.1.7/exe/rspec --pattern 'C:/tmp/busser/suites/serverspec/**/*_spec.rb' --color --format documentation --default-path C:/tmp/busser/suites/serverspec
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #verify action: [Transport WinRM exited (1) using shell [powershell] for command: [$env:BUSSER_ROOT="/tmp/busser"; $env:GEM_HOME="/tmp/busser/gems"; $env:GEM_PATH="/tmp/busser/gems"; $env:PATH="$env:PATH;$env:GEM_PATH/bin"; try { $env:BUSSER_SUITE_PATH=@(busser suite path) } catch { $env:BUSSER_SUITE_PATH="" }; $env:GEM_CACHE="/tmp/busser/gems/cache"

busser test
]
REMOTE ERROR:
C:/tmp/busser/suites/serverspec/spec_helper.rb:3:in `<top (required)>': uninitialized constant Serverspec::Helper::Cmd (NameError)
    from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from C:/tmp/busser/suites/serverspec/localhost/default_spec.rb:1:in `<top (required)>'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `each'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in `run'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
    from C:/tmp/busser/gems/gems/rspec-core-3.1.7/exe/rspec:4:in `<main>'
C:/opscode/chef/embedded/bin/ruby.exe -IC:/tmp/busser/suites/serverspec -I'C:/tmp/busser/gems/gems/rspec-support-3.1.2/lib';'C:/tmp/busser/gems/gems/rspec-core-3.1.7/lib' C:/tmp/busser/gems/gems/rspec-core-3.1.7/exe/rspec --pattern 'C:/tmp/busser/suites/serverspec/**/*_spec.rb' --color --format documentation --default-path C:/tmp/busser/suites/serverspec failed
Ruby Script [C:/tmp/busser/gems/gems/busser-serverspec-0.5.3/lib/busser/runner_plugin/../serverspec/runner.rb /tmp/busser/suites/serverspec] exit code was 1
]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```
